### PR TITLE
Correctly display LLVM IR in playground

### DIFF
--- a/docker/bin/compile.sh
+++ b/docker/bin/compile.sh
@@ -14,3 +14,4 @@ printf '\377' # 255 in octal
 
 [ -f main.ll ] && cat main.ll
 [ -f main.s ] && cat main.s
+rm -f main.*


### PR DESCRIPTION
We need to remove detrus from one run to another otherwise
only the 2nd of the .s and .ll as listed in compile.sh will
be displayed.

Closes #1