### PR TITLE
[3/?] Add ability to run code examples in the playground: Fetch tutorial snippet from URL by file name

### DIFF
--- a/static/web.js
+++ b/static/web.js
@@ -293,7 +293,7 @@
     }
 
     function fetchSnippet(session, result, snippet_file_name, do_evaluate, evaluateButton) {
-        session.setValue("// Loading snippet: https://github.com/ponylang/pony-tutorial/blob/cmain/code-samples/actors-behaviors.pony" + snippet_file_name + " ...");
+        session.setValue("// Loading snippet: https://github.com/ponylang/pony-tutorial/blob/cmain/code-samples/" + snippet_file_name + " ...");
         httpRequest("GET", "https://raw.githubusercontent.com/ponylang/pony-tutorial/main/code-samples/" + snippet_file_name, null, 200,
             function (response) {
                 session.setValue(response);

--- a/static/web.js
+++ b/static/web.js
@@ -536,9 +536,9 @@
             // fetchGist() must defer evaluation until after the content has been loaded
             fetchGist(session, result, query.gist, query.run === "1", evaluateButton);
             query.run = 0;
-        } else if ("snippet" in query) {
+        } else if (query.has("snippet")) {
             // fetchSnippet() must defer evaluation until after the content has been loaded
-            fetchSnippet(session, result, query.snippet, query.run === "1", evaluateButton);
+            fetchSnippet(session, result, query.get("snippet"), query.get("run") === "1", evaluateButton);
             query.run = 0;
         } else {
             var code = optionalLocalStorageGetItem("code");

--- a/static/web.js
+++ b/static/web.js
@@ -370,7 +370,7 @@
      */
     function fetchSnippet(session, result, snippet_file_name, do_evaluate, evaluateButton) {
         session.setValue("// Loading snippet: https://github.com/ponylang/pony-tutorial/blob/main/code-samples/" + snippet_file_name + " ...");
-        httpRequest("GET", "https://raw.githubusercontent.com/ponylang/pony-tutorial/" + (query.get("branch") ?? "main") + "/code-samples/" + snippet_file_name, null, 200,
+        httpRequest("GET", "https://raw.githubusercontent.com/ponylang/pony-tutorial/main/code-samples/" + snippet_file_name, null, 200,
             function (response) {
                 session.setValue(response);
 

--- a/static/web.js
+++ b/static/web.js
@@ -293,7 +293,7 @@
     }
 
     function fetchSnippet(session, result, snippet_file_name, do_evaluate, evaluateButton) {
-        session.setValue("// Loading snippet: https://github.com/ponylang/pony-tutorial/blob/cmain/code-samples/" + snippet_file_name + " ...");
+        session.setValue("// Loading snippet: https://github.com/ponylang/pony-tutorial/blob/main/code-samples/" + snippet_file_name + " ...");
         httpRequest("GET", "https://raw.githubusercontent.com/ponylang/pony-tutorial/main/code-samples/" + snippet_file_name, null, 200,
             function (response) {
                 session.setValue(response);

--- a/static/web.js
+++ b/static/web.js
@@ -320,7 +320,7 @@
       }
 
     /**
-     * 
+     * Fetches a gist from the [gist.github.com](https://gist.github.com/) and loads it into the code editor
      * @param {Ace.EditSession} session (see [ace.Ace.Editor::getSession](https://ajaxorg.github.io/ace-api-docs/interfaces/ace.Ace.Editor.html#getSession))
      * @param {HTMLDivElement} result 
      * @param {String} gist_id 
@@ -358,6 +358,16 @@
         );
     }
 
+    /**
+     * Fetches a code snippet from the [`ponylang/pony-tutorial`](https://github.com/ponylang/pony-tutorial) repository on GitHub
+     * and loads it into the code editor
+     * @param {Ace.EditSession} session (see [ace.Ace.Editor::getSession](https://ajaxorg.github.io/ace-api-docs/interfaces/ace.Ace.Editor.html#getSession))
+     * @param {HTMLDivElement} result 
+     * @param {String} gist_id 
+     * @param {bool} do_evaluate 
+     * @param {HTMLButtonElement} evaluateButton 
+     * @return {void}
+     */
     function fetchSnippet(session, result, snippet_file_name, do_evaluate, evaluateButton) {
         session.setValue("// Loading snippet: https://github.com/ponylang/pony-tutorial/blob/main/code-samples/" + snippet_file_name + " ...");
         httpRequest("GET", "https://raw.githubusercontent.com/ponylang/pony-tutorial/" + (query.get("branch") ?? "main") + "/code-samples/" + snippet_file_name, null, 200,

--- a/static/web.js
+++ b/static/web.js
@@ -292,6 +292,23 @@
         );
     }
 
+    function fetchSnippet(session, result, snippet_file_name, do_evaluate, evaluateButton) {
+        session.setValue("// Loading snippet: https://github.com/ponylang/pony-tutorial/blob/cmain/code-samples/actors-behaviors.pony" + snippet_file_name + " ...");
+        httpRequest("GET", "https://raw.githubusercontent.com/ponylang/pony-tutorial/main/code-samples/" + snippet_file_name, null, 200,
+            function (response) {
+                session.setValue(response);
+
+                if (do_evaluate) {
+                    doEvaluate();
+                }
+            },
+            function (status, response) {
+                set_result(result, "<p class=error>Failed to fetch snippet" +
+                    "<p class=error-explanation>Are you connected to the Internet?");
+            }
+        );
+    }
+
     function getQueryParameters() {
         var a = window.location.search.substr(1).split('&');
         if (a === "") return {};
@@ -518,6 +535,10 @@
         } else if ("gist" in query) {
             // fetchGist() must defer evaluation until after the content has been loaded
             fetchGist(session, result, query.gist, query.run === "1", evaluateButton);
+            query.run = 0;
+        } else if ("snippet" in query) {
+            // fetchSnippet() must defer evaluation until after the content has been loaded
+            fetchSnippet(session, result, query.snippet, query.run === "1", evaluateButton);
             query.run = 0;
         } else {
             var code = optionalLocalStorageGetItem("code");

--- a/static/web.js
+++ b/static/web.js
@@ -294,7 +294,7 @@
 
     function fetchSnippet(session, result, snippet_file_name, do_evaluate, evaluateButton) {
         session.setValue("// Loading snippet: https://github.com/ponylang/pony-tutorial/blob/main/code-samples/" + snippet_file_name + " ...");
-        httpRequest("GET", "https://raw.githubusercontent.com/ponylang/pony-tutorial/main/code-samples/" + snippet_file_name, null, 200,
+        httpRequest("GET", "https://raw.githubusercontent.com/ponylang/pony-tutorial/" + (query.get("branch") ?? "main") + "/code-samples/" + snippet_file_name, null, 200,
             function (response) {
                 session.setValue(response);
 


### PR DESCRIPTION
See https://github.com/ponylang/pony-tutorial/issues/340

> [!WARNING]
Will only work, after #222 has been merged.

Example: https://playground.ponylang.io/?snippet=hello-world-main.pony

If we add `.layer(CorsLayer::permissive())` here, we could even call the API from the tutorial and display the result below the code block (apparently, this had already been done in 2014, when the API was still written in Python: https://github.com/ponylang/pony-playground/commit/02d0a985a45ebe08349cfb292838a4cd7f24730a):
https://github.com/ponylang/pony-playground/blob/59b1ffdac935f27cd73d7fd77ff380e7a38e9b7d/src/api.rs#L31
or, if we want to be a little more restrictive, it could look like this:
```rust
use http::HeaderValue;
use tower_http::cors::CorsLayer;

let layer = CorsLayer::new().allow_origin(
    "https://tutorial.ponylang.io".parse::<HeaderValue>().unwrap(),
);
let router = Router::new()
        .route(
            "/",
            get(|| async { static_html(include_bytes!("../static/web.html")) }),
        )
        .route("/evaluate.json", post(evaluate))
        .layer(layer)
        // ...
```