### PR TITLE
Add GitHub Action to manually update the playground

### DIFF
--- a/.github/workflows/update-playground.yml
+++ b/.github/workflows/update-playground.yml
@@ -1,0 +1,21 @@
+name: Update Playground
+
+on:
+  workflow_dispatch
+
+concurrency:
+  group: "update-playground"
+  cancel-in-progress: false
+
+jobs:
+  update-playground:
+    name: Update https://playground.ponylang.io/
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run remote command
+        uses: ponylang-main/ssh-action@ffff33f8fe0318345a4f00f0e847325954b2a3ed
+        with:
+          host: ${{ secrets.PLAYGROUND_HOST }}
+          username: ${{ secrets.PLAYGROUND_ADMIN_USER }}
+          key: ${{ secrets.PLAYGROUND_KEY }}
+          script: bash update-playground.bash


### PR DESCRIPTION
To be used if any dependencies have a critical vulnerability and we need to update outside of a release.