### PR TITLE
[5/?] Add ability to run code examples in the playground: Add CORS exception for tutorial.ponylang.io to route /evaluate.json

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = "1.0"
 tokio = { version = "1.37", features = ["full"] }
 wait-timeout = "0.2"
 url = { version = "2.5", "features" = ["serde"] }
+tower-http = { version = "0.5", features = ["cors"] }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/src/api.rs
+++ b/src/api.rs
@@ -10,7 +10,7 @@ use axum::http::HeaderValue;
 use std::net::SocketAddr;
 use tower_http::cors::CorsLayer;
 
-const layer: CorsLayer = CorsLayer::new().allow_origin(
+let layer: CorsLayer = CorsLayer::new().allow_origin(
     "https://tutorial.ponylang.io"
         .parse::<HeaderValue>()
         .unwrap(),

--- a/src/api.rs
+++ b/src/api.rs
@@ -6,12 +6,14 @@ use axum::{
 
 use crate::routes::{compile, create_gist, evaluate, static_css, static_html, static_js};
 use crate::GithubClient;
-use std::net::SocketAddr;
 use http::HeaderValue;
+use std::net::SocketAddr;
 use tower_http::cors::CorsLayer;
 
 const layer: CorsLayer = CorsLayer::new().allow_origin(
-    "https://tutorial.ponylang.io".parse::<HeaderValue>().unwrap(),
+    "https://tutorial.ponylang.io"
+        .parse::<HeaderValue>()
+        .unwrap(),
 );
 
 /// serve the api

--- a/src/api.rs
+++ b/src/api.rs
@@ -10,7 +10,7 @@ use std::net::SocketAddr;
 use http::HeaderValue;
 use tower_http::cors::CorsLayer;
 
-const layer = CorsLayer::new().allow_origin(
+const layer: CorsLayer = CorsLayer::new().allow_origin(
     "https://tutorial.ponylang.io".parse::<HeaderValue>().unwrap(),
 );
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -7,6 +7,12 @@ use axum::{
 use crate::routes::{compile, create_gist, evaluate, static_css, static_html, static_js};
 use crate::GithubClient;
 use std::net::SocketAddr;
+use http::HeaderValue;
+use tower_http::cors::CorsLayer;
+
+let layer = CorsLayer::new().allow_origin(
+    "https://tutorial.ponylang.io".parse::<HeaderValue>().unwrap(),
+);
 
 /// serve the api
 pub async fn serve(addr: SocketAddr, github_client: GithubClient) -> Result<()> {
@@ -24,11 +30,12 @@ pub async fn serve(addr: SocketAddr, github_client: GithubClient) -> Result<()> 
             get(|| async { static_js(include_bytes!("../static/mode-pony.js")) }),
         );
     let router = Router::new()
+        .route("/evaluate.json", post(evaluate))
+        .layer(layer) // applies to every route() call before on `router`
         .route(
             "/",
             get(|| async { static_html(include_bytes!("../static/web.html")) }),
         )
-        .route("/evaluate.json", post(evaluate))
         .route("/compile.json", post(compile))
         .route("/gist.json", post(create_gist))
         .with_state(github_client)

--- a/src/api.rs
+++ b/src/api.rs
@@ -10,14 +10,14 @@ use axum::http::HeaderValue;
 use std::net::SocketAddr;
 use tower_http::cors::CorsLayer;
 
-let layer: CorsLayer = CorsLayer::new().allow_origin(
-    "https://tutorial.ponylang.io"
-        .parse::<HeaderValue>()
-        .unwrap(),
-);
-
 /// serve the api
 pub async fn serve(addr: SocketAddr, github_client: GithubClient) -> Result<()> {
+    let layer: CorsLayer = CorsLayer::new().allow_origin(
+        "https://tutorial.ponylang.io"
+            .parse::<HeaderValue>()
+            .unwrap(),
+    );
+
     let static_routes = Router::new()
         .route(
             "/web.css",

--- a/src/api.rs
+++ b/src/api.rs
@@ -10,7 +10,7 @@ use std::net::SocketAddr;
 use http::HeaderValue;
 use tower_http::cors::CorsLayer;
 
-let layer = CorsLayer::new().allow_origin(
+const layer = CorsLayer::new().allow_origin(
     "https://tutorial.ponylang.io".parse::<HeaderValue>().unwrap(),
 );
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -6,7 +6,7 @@ use axum::{
 
 use crate::routes::{compile, create_gist, evaluate, static_css, static_html, static_js};
 use crate::GithubClient;
-use http::HeaderValue;
+use axum::http::HeaderValue;
 use std::net::SocketAddr;
 use tower_http::cors::CorsLayer;
 


### PR DESCRIPTION
See https://github.com/ponylang/pony-tutorial/issues/340

As discussed in #205