### PR TITLE
Update compile test assertions for new ponyc name mangling

### DIFF
--- a/tests/api.rs
+++ b/tests/api.rs
@@ -95,7 +95,7 @@ async fn compile() -> Result<()> {
         payload
             .result
             .unwrap_or_default()
-            .contains("@Main_tag_create_oo")
+            .contains("@Main_tag_create_ioo")
     );
 
     // compile with asm output
@@ -117,7 +117,7 @@ async fn compile() -> Result<()> {
         payload
             .result
             .unwrap_or_default()
-            .contains("Main_tag_create_oo:")
+            .contains("Main_tag_create_ioo:")
     );
 
     // invalid input


### PR DESCRIPTION
ponyc now includes trace-kind characters in mangled names for
constructors and behaviors. `Env val` produces trace-kind `i`
(immutable), changing the mangled name from `Main_tag_create_oo`
to `Main_tag_create_ioo`.